### PR TITLE
(SIMP-1574) Fix `pe` dependency syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2016-09-29 - Release 0.3.2
+### Summary
+Fixed malformed `pe` dependency in `metadata.json`
+
+#### Authors
+- Chris Tessmer <chris.tessmer@onyxpoint.com>
+
+#### Features
+- Fixed syntax to enable publishing to the Forge
+
 ## 2016-07-07 - Release 0.3.1
 ### Summary
 Updated module for auto lua spec generation

--- a/metadata.json
+++ b/metadata.json
@@ -1,30 +1,44 @@
 {
   "name": "simp-haveged",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "author": "simp",
   "summary": "Install and manage the HAVEGE daemon.",
   "license": "BSD-2-Clause",
   "source": "https://github.com/simp/puppet-haveged",
   "project_page": "https://github.com/simp/puppet-haveged",
   "issues_url": "https://simp-project.atlassian.net",
-  "tags": [ "simp", "haveged", "entropy", "random" ],
+  "tags": [
+    "simp",
+    "haveged",
+    "entropy",
+    "random"
+  ],
   "operatingsystem_support": [
     {
       "operatingsystem": "RedHat",
-      "operatingsystemrelease": [ "6", "7" ]
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
     },
     {
       "operatingsystem": "CentOS",
-      "operatingsystemrelease": [ "6", "7" ]
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
     }
   ],
   "dependencies": [
-    { "name": "puppetlabs/stdlib", "version_requirement": "4.x" }
+    {
+      "name": "puppetlabs/stdlib",
+      "version_requirement": "4.x"
+    }
   ],
   "requirements": [
     {
       "name": "pe",
-      "version_requirement": ">= 3.2.0 < 2017.0"
+      "version_requirement": ">= 3.2.0 < 2017.0.0"
     },
     {
       "name": "puppet",


### PR DESCRIPTION
The `'pe'` dependency syntax was malformed, which disabled pushing to
the Forge.  This commit fixes the syntax.

SIMP-1574 #close #comment Fixed `pe` dependency syntax in metadata.json
