### PR TITLE
(SIMP-1692) Point fixtures to `5.X` branches

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,7 +1,8 @@
+---
 fixtures:
   repositories:
-    'stdlib':
-      repo: "https://github.com/simp/puppetlabs-stdlib"
-      branch: 'simp-master'
+    stdlib:
+      branch: 5.X
+      repo: https://github.com/simp/puppetlabs-stdlib
   symlinks:
-    'haveged': "#{source_dir}"
+    haveged: "#{source_dir}"


### PR DESCRIPTION
This commit marks the transition of mainline SIMP development away from
4.x/5.x.  From this point on, the `master` branch will be used to target SIMP
6.x.

This commit updates `fixtures.yml` to reference the newly-created `5.X` branch
in each `simp/` repository.

SIMP-1692 #comment updated `.fixtures.yml` in haveged
