### PR TITLE
(SIMP-1738) Correctly bind gems in `5.X Gemfile`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,33 +1,20 @@
 # ------------------------------------------------------------------------------
-# Environment variables:
-#   SIMP_GEM_SERVERS | a space/comma delimited list of rubygem servers
-#   PUPPET_VERSION   | specifies the version of the puppet gem to load
-# ------------------------------------------------------------------------------
 # NOTE: SIMP Puppet rake tasks support ruby 2.0 and ruby 2.1
 # ------------------------------------------------------------------------------
-puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : '~>3'
 gem_sources   = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[, ]+/) : ['https://rubygems.org']
 
 gem_sources.each { |gem_source| source gem_source }
 
 group :test do
   gem "rake"
-  gem 'puppet', puppetversion
+  gem 'puppet', ENV.fetch('PUPPET_VERSION',  '~>3')
   gem "rspec", '< 3.2.0'
   gem "rspec-puppet"
   gem "hiera-puppet-helper"
   gem "puppetlabs_spec_helper"
   gem "metadata-json-lint"
-  gem "simp-rspec-puppet-facts", "~> 1.3"
-
-
-  # simp-rake-helpers does not suport puppet 2.7.X
-  if "#{ENV['PUPPET_VERSION']}".scan(/\d+/).first != '2' &&
-      # simp-rake-helpers and ruby 1.8.7 bomb Travis tests
-      # TODO: fix upstream deps (parallel in simp-rake-helpers)
-      RUBY_VERSION.sub(/\.\d+$/,'') != '1.8'
-    gem 'simp-rake-helpers'
-  end
+  gem "simp-rspec-puppet-facts", ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 1.3')
+  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 2.5')
 end
 
 group :development do
@@ -47,5 +34,5 @@ end
 group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
-  gem 'simp-beaker-helpers', '>= 1.0.5'
+  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 1.5')
 end

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -27,10 +27,22 @@
 #
 #
 class haveged::config (
-  $buffer_size            =  defined('$::haveged::buffer_size') ? { true => getvar('::haveged::buffer_size'), default => undef },
-  $data_cache_size        =  defined('$::haveged::data_cache_size') ? { true => getvar('::haveged::data_cache_size'), default => undef },
-  $instruction_cache_size =  defined('$::haveged::instruction_cache_size') ? { true => getvar('::haveged::instruction_cache_size'), default => undef },
-  $write_wakeup_threshold =  defined('$::haveged::write_wakeup_threshold') ? { true => getvar('::haveged::write_wakeup_threshold'), default => undef }
+  $buffer_size            =  defined('$::haveged::buffer_size') ? {
+    true => getvar('::haveged::buffer_size'),
+    default => undef
+  },
+  $data_cache_size        =  defined('$::haveged::data_cache_size') ? {
+    true => getvar('::haveged::data_cache_size'),
+    default => undef
+  },
+  $instruction_cache_size =  defined('$::haveged::instruction_cache_size') ? {
+    true => getvar('::haveged::instruction_cache_size'),
+    default => undef
+  },
+  $write_wakeup_threshold =  defined('$::haveged::write_wakeup_threshold') ? {
+    true => getvar('::haveged::write_wakeup_threshold'),
+    default => undef
+  }
 ) inherits ::haveged::params {
 
   # Validate numeric parameters

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -23,8 +23,14 @@
 #
 #
 class haveged::package (
-  $package_name   = defined('$::haveged::package_name') ? { true => getvar('::haveged::package_name'), default => $::haveged::params::package_name },
-  $package_ensure = defined('$::haveged::_package_ensure') ? { true => getvar('::haveged::_package_ensure'), false => 'present' },
+  $package_name   = defined('$::haveged::package_name') ? {
+    true => getvar('::haveged::package_name'),
+    default => $::haveged::params::package_name
+  },
+  $package_ensure = defined('$::haveged::_package_ensure') ? {
+    true => getvar('::haveged::_package_ensure'),
+    false => 'present'
+  },
 ) inherits ::haveged::params {
 
   # Working around a bug in the package type

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -23,9 +23,18 @@
 #
 #
 class haveged::service (
-  $service_name   = defined('$::haveged::service_name') ? { true => getvar('::haveged::service_name'), default => $::haveged::params::service_name },
-  $service_ensure = defined('$::haveged::_service_ensure') ? { true => getvar('::haveged::_service_ensure'), default => 'running' },
-  $service_enable = defined('$::haveged::_service_enable') ? { true => getvar('::haveged::_service_enable'), default => true }
+  $service_name   = defined('$::haveged::service_name') ? {
+    true => getvar('::haveged::service_name'),
+    default => $::haveged::params::service_name
+  },
+  $service_ensure = defined('$::haveged::_service_ensure') ? {
+    true => getvar('::haveged::_service_ensure'),
+    default => 'running'
+  },
+  $service_enable = defined('$::haveged::_service_enable') ? {
+    true => getvar('::haveged::_service_enable'),
+    default => true
+  }
 ) inherits ::haveged::params {
 
   service { $service_name:


### PR DESCRIPTION
This commit pins the `simp-rake-helpers` gem in the `Gemfile` so that
subsequent upgrades will not break `bundle update` inside the `5.X`
branch.

SIMP-1738 #comment Bound gems in puppet-haveged `Gemfile`
SIMP-1780 #close
