### PR TITLE
(SIMP-2111) Incorrect Changelog Entry

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-* Mon Nov 21 2016 Chris Tessmer <chris.tessmer@onyxpoint.com> - 0.3.3-0
+* Mon 21 Nov 2016 Chris Tessmer <chris.tessmer@onyxpoint.com> - 0.3.3-0
 - Updated to compliance_markup version 2
 
 * Thu 29 Sep 2016 Chris Tessmer <chris.tessmer@onyxpoint.com> - 0.3.2-0

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-haveged",
-  "version": "0.3.4",
+  "version": "0.3.3",
   "author": "SIMP Team",
   "summary": "Install and manage the HAVEGE daemon.",
   "license": "BSD-2-Clause",


### PR DESCRIPTION
When pulling the changes from master into 5.X, discovered that there was an incorrect changelog entry present which would cause the builds to fail on some systems.

SIMP-2111 #close