### PR TITLE
(SIMP-2111) Reverted Gemfile for 5.X

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ group :test do
   gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
   gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 1.3')
-  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 3.0')
+  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 2.5')
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem_sources.each { |gem_source| source gem_source }
 
 group :test do
   gem 'rake'
-  gem 'puppet', ENV.fetch('PUPPET_VERSION',  '~>4')
+  gem 'puppet', ENV.fetch('PUPPET_VERSION',  '~>3.8')
   gem 'rspec'
   gem 'rspec-puppet'
   gem 'hiera-puppet-helper'


### PR DESCRIPTION
The 5.X series needs the old Gemfile for the old simp-rake-helpers so
that we build the correct RPM dependencies.

SIMP-2111 #close