### PR TITLE
(SIMP-2670) Update invalid dependency boundaries

### DIFF
--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,0 +1,4 @@
+Requires: pupmod-puppetlabs-stdlib < 5.0.0-0
+Requires: pupmod-puppetlabs-stdlib >= 4.13.1-0
+Requires: pupmod-simp-simplib < 4.0.0-0
+Requires: pupmod-simp-simplib >= 3.2.0-0

--- a/metadata.json
+++ b/metadata.json
@@ -32,11 +32,11 @@
   "dependencies": [
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 2.1.0 < 3.0.0"
+      "version_requirement": ">= 3.2.0 < 4.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.9.0 < 5.0.0"
+      "version_requirement": ">= 4.13.1 < 5.0.0"
     }
   ],
   "requirements": [

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -82,7 +82,6 @@ RSpec.configure do |c|
   # If nothing else...
   c.default_facts = {
     :production => {
-      #:fqdn           => 'production.rspec.test.localdomain',
       :path           => '/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin',
       :concat_basedir => '/tmp'
     }


### PR DESCRIPTION
Before this patch, dependencies in `metadata.json` referred to old versions
that would be invalid in SIMP 6.0.0.

This commit resolves the issue by updating the upper and lower
boundaries for each dependency in `metadata.json` to match the version
found in SIMP-6.0.0.

SIMP-2670 #comment Fixed `pupmod-simp-haveged`