### PR TITLE
(SIMP-3453) haveged - fix bad tag

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Thu Jul 20 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 0.4.2-0
+- Fix bad tag.  simp-0.4.1 tag was made off of master branch.
+
 * Thu Jul 06 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 0.4.1-0
 - Update puppet dependency in metadata.json
 - Remove OBE pe dependency in metadata.json


### PR DESCRIPTION
simp-4.1.0 tag was generated off of master.
Should have been 4.1.0 tag off of simp-master.
To avoid any confusion, we will bump the version on simp-master
and correctly tag.

SIMP-3453 #close