### PR TITLE
(SIMP-3483) Fix bad 0.4.2 tag.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Thu Jul 20 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 0.4.3-0
+- Fix bad 0.4.2 tag.  In that tag, the metadata.json was incorrect.
+
 * Thu Jul 20 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 0.4.2-0
 - Fix bad tag.  simp-0.4.1 tag was made off of master branch.
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-haveged",
-  "version": "0.4.1",
+  "version": "0.4.3",
   "author": "SIMP Team",
   "summary": "Install and manage the HAVEGE daemon.",
   "license": "BSD-2-Clause",


### PR DESCRIPTION
The last tag, 0.4.2, had an incorrect version in its metadata.json,
and had incorrectly-formatted release notes on github.  This version
is to address those problems.

SIMP-3483 #close