### PR TITLE
(SIMP-9710) Fix service disable

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,12 @@
+* Wed May 26 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.7.1
+- Fixed
+  - Mask the service when disabling for rngd compatibility so that it is not
+    restarted on reboot
+
+- Changed
+  - Support puppetlabs/stdlib 7.X
+  - Updated REFERENCE.md
+
 * Wed Feb 03 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.7.0
 - Ensure that haveged does not start by default if rngd is running
 - Add `haveged__rngd_enabled` fact

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -9,6 +9,7 @@
 * [`haveged`](#haveged): Manage HAVEGEd  == Sample Usage:    class { 'haveged':     write_wakeup_threshold => 1024,   }
 * [`haveged::config`](#havegedconfig): Manage the HAVEGEd configuration file
 * [`haveged::package`](#havegedpackage): Manage the haveged package
+* [`haveged::service`](#havegedservice): Manage the HAVEGEd service
 
 ## Classes
 
@@ -79,7 +80,7 @@ Default value: `'haveged'`
 
 ##### <a name="service_ensure"></a>`service_ensure`
 
-Data type: `String[1]`
+Data type: `Variant[Boolean,String[1]]`
 
 Whether the service should be running
 
@@ -103,7 +104,7 @@ Default value: `'haveged'`
 
 ##### <a name="package_ensure"></a>`package_ensure`
 
-Data type: `Simplib::PackageEnsure`
+Data type: `Variant[Boolean,Simplib::PackageEnsure]`
 
 Ensure parameter passed onto Package resources. Default: 'present'
 
@@ -181,4 +182,52 @@ Data type: `Simplib::PackageEnsure`
 Ensure parameter passed onto Package resources
 
 Default value: `defined('$haveged::_package_ensure')`
+
+### <a name="havegedservice"></a>`haveged::service`
+
+Manage the HAVEGEd service
+
+#### Parameters
+
+The following parameters are available in the `haveged::service` class:
+
+* [`service_name`](#service_name)
+* [`service_ensure`](#service_ensure)
+* [`service_enable`](#service_enable)
+* [`force_if_rngd_running`](#force_if_rngd_running)
+
+##### <a name="service_name"></a>`service_name`
+
+Data type: `String[1]`
+
+The name of the service to manage
+
+Default value: `defined('$haveged::service_name')`
+
+##### <a name="service_ensure"></a>`service_ensure`
+
+Data type: `String[1]`
+
+Whether the service should be running
+
+Default value: `defined('$haveged::_service_ensure')`
+
+##### <a name="service_enable"></a>`service_enable`
+
+Data type: `Boolean`
+
+Whether the service should be enabled to start at boot time
+
+Default value: `defined('$haveged::_service_enable')`
+
+##### <a name="force_if_rngd_running"></a>`force_if_rngd_running`
+
+Data type: `Boolean`
+
+Will force haveged to start even though RNGD is already running
+
+* While this should not harm your system in most cases, it is also adding
+  an unnecessary process running on the system
+
+Default value: ``false``
 

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -24,7 +24,7 @@ class haveged::service (
   if $facts['haveged__rngd_enabled'] and !$force_if_rngd_running {
     service {$service_name:
       ensure => 'stopped',
-      enable => false
+      enable => 'mask'
     }
   }
   else {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-haveged",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "author": "SIMP Team",
   "summary": "Install and manage the HAVEGE daemon.",
   "license": "BSD-2-Clause",
@@ -24,7 +24,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 7.0.0"
+      "version_requirement": ">= 4.13.1 < 8.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -22,8 +22,15 @@ describe 'haveged' do
         end
       end
 
-      it 'should be stopped if rngd is running' do
+      it 'should be stopped if rngd is running and remain stopped after reboot' do
         unless on(host, 'pgrep rngd 2>/dev/null', :accept_all_exit_codes => true).stdout.strip.empty?
+          on(host, 'puppet resource service haveged') do
+            expect(stdout).to match(/ensure\s*=> 'stopped'/)
+            expect(stdout).to match(/enable\s*=> 'false'/)
+          end
+
+          host.reboot
+
           on(host, 'puppet resource service haveged') do
             expect(stdout).to match(/ensure\s*=> 'stopped'/)
             expect(stdout).to match(/enable\s*=> 'false'/)

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -23,7 +23,7 @@ describe 'haveged::service' do
         it {
           is_expected.to contain_service('haveged')
             .with_ensure('stopped')
-            .with_enable(false)
+            .with_enable('mask')
         }
 
         context 'with haveged forced' do


### PR DESCRIPTION
- Fixed
  - Mask the service when disabling for rngd compatibility so that it is not
    restarted on reboot

- Changed
  - Support puppetlabs/stdlib 7.X
  - Updated REFERENCE.md

SIMP-9710 #close