### PR TITLE
(SIMP-MAINT) haveged Remove invalid blank line within CHANGELOG entry

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,7 +9,6 @@
 - Fixed
   - Mask the service when disabling for rngd compatibility so that it is not
     restarted on reboot
-
 - Changed
   - Support puppetlabs/stdlib 7.X
   - Updated REFERENCE.md


### PR DESCRIPTION
Remove a blank line that causes information to be missed when
the tag changelog is generated.