### PR TITLE
Update deps to use puppet/systemd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,12 @@
 .idea/
 dist
 /pkg
-/spec/fixtures
+# Read everything in fixtures
+/spec/fixtures/*
+# Un-ignore hieradata
+!/spec/fixtures/hieradata/*
+# Except this one, which is auto-generated
+/spec/fixtures/hieradata/hiera.yaml
 /spec/rp_env
 /.rspec_system
 /.vagrant

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri Jun 03 2022 Chris Tessmer <chris.tessmer@onyxpoint.com> - 0.9.0
+- Update from camptocamp/systemd to puppet/systemd
+
 * Wed Jun 23 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.8.0
 - Updated the README
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-haveged",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "author": "SIMP Team",
   "summary": "Install and manage the HAVEGE daemon.",
   "license": "BSD-2-Clause",
@@ -15,8 +15,8 @@
   ],
   "dependencies": [
     {
-      "name": "camptocamp/systemd",
-      "version_requirement": ">= 2.2.0 < 3.0.0"
+      "name": "puppet/systemd",
+      "version_requirement": ">= 3.0.0 < 4.0.0"
     },
     {
       "name": "simp/simplib",


### PR DESCRIPTION
This patch updates from camptocamp/systemd 2.x to puppet/systemd 3.x

This bump is driven by simp/simp-core#829