### PR TITLE
Fixes to support new puppet/systemd (#62)

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,6 +3,8 @@ fixtures:
   repositories:
     stdlib: https://github.com/simp/puppetlabs-stdlib.git
     simplib: https://github.com/simp/pupmod-simp-simplib.git
-    systemd: https://github.com/simp/puppet-systemd.git
+    systemd:
+      repo: https://github.com/simp/puppet-systemd.git
+      branch: simp-master
   symlinks:
     haveged: "#{source_dir}"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Mon Jun 06 2022 Chris Tessmer <chris.tessmer@onyxpoint.com> - 0.9.1
+- Fixed:
+  - Remove deprecated `daemon_reload` parameter from `systemd::dropin_file`
+
 * Fri Jun 03 2022 Chris Tessmer <chris.tessmer@onyxpoint.com> - 0.9.0
 - Update from camptocamp/systemd to puppet/systemd
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -50,6 +50,5 @@ class haveged::config (
   systemd::dropin_file { 'haveged_settings.conf':
     unit          => 'haveged.service',
     content       => $_systemd_conf,
-    daemon_reload => 'eager'
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-haveged",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "author": "SIMP Team",
   "summary": "Install and manage the HAVEGE daemon.",
   "license": "BSD-2-Clause",


### PR DESCRIPTION
This patch removes the deprecated `daemon_reload` parameter from
`systemd::dropin_file` and corrects the systemd branch used by the spec
tests' module fixtures

This fix supports simp/simp-core#829