### PR TITLE
Add RockyLinux 8 support

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -109,14 +109,16 @@ jobs:
     strategy:
       matrix:
         puppet:
-          - label: 'Puppet 7.x'
-            puppet_version: '~> 7.21.0'
+          - label: 'Puppet 7.x [SIMP 6.6/PE 2021.7]'
+            puppet_version: '~> 7.0'
             ruby_version: '2.7'
+            experimental: false
           - label: 'Puppet 8.x'
             puppet_version: '~> 8.0'
-            ruby_version: '3.2'
+            ruby_version: 3.1
+            experimental: true
     env:
-      PUPPET_VERSION: '${{matrix.puppet.puppet_version}}'
+      PUPPET_VERSION: ${{matrix.puppet.puppet_version}}
     steps:
       - uses: actions/checkout@v3
       - name: 'Install Ruby ${{matrix.puppet.ruby_version}}'
@@ -126,6 +128,7 @@ jobs:
           bundler-cache: true
       - run: 'command -v rpm || if command -v apt-get; then sudo apt-get update; sudo apt-get install -y rpm; fi ||:'
       - run: 'bundle exec rake spec'
+        continue-on-error: ${{matrix.puppet.experimental}}
 
 #  dump_contexts:
 #    name: 'Examine Context contents'

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -9,7 +9,7 @@
 --no-class_inherits_from_params_class-check
 --no-140chars-check
 --no-trailing_comma-check
---no-empty_string_assignment-check
+--no-params-empty-string-assignment-check
 # This is here because the code can't handle lookups in parameters and SIMP
 # modules have a LOT of those
 --no-parameter_order-check

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon Jun 12 2023 Chris Tessmer <chris.tessmer@onyxpoint.com> - 0.12.0
+- Add RockyLinux 8 support
+
 * Sun Dec 18 2022 Trevor Vaughan <trevor@sicura.us> - 0.11.0
 - Added:
   - The module now supports Alma Linux 8 and Rocky Linux 8

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ group :test do
   gem 'puppetlabs_spec_helper'
   gem 'metadata-json-lint'
   gem 'puppet-strings'
-  gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
   gem 'simp-rspec-puppet-facts', ENV['SIMP_RSPEC_PUPPET_FACTS_VERSION'] || '~> 3.1'
   gem 'simp-rake-helpers', ENV['SIMP_RAKE_HELPERS_VERSION'] || ['>= 5.12.1', '< 6']

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -48,7 +48,7 @@ class haveged::config (
     | END
 
   systemd::dropin_file { 'haveged_settings.conf':
-    unit          => 'haveged.service',
-    content       => $_systemd_conf,
+    unit    => 'haveged.service',
+    content => $_systemd_conf,
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,7 +38,7 @@ class haveged (
   Optional[Variant[String,Integer]]       $buffer_size            = undef,
   Optional[Variant[String,Integer]]       $data_cache_size        = undef,
   Optional[Variant[String,Integer]]       $instruction_cache_size = undef,
-  Optional[Variant[String,Integer]]       $write_wakeup_threshold = 1024,
+  Variant[String,Integer]                 $write_wakeup_threshold = 1024,
   String[1]                               $service_name           = 'haveged',
   Boolean                                 $service_enable         = true,
   Variant[Boolean,String[1]]              $service_ensure         = 'running',

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -12,7 +12,7 @@ class haveged::package (
 ) {
   # Working around a bug in the package type
   # https://tickets.puppetlabs.com/browse/PUP-1295
-  if ($facts['osfamily'] == 'RedHat') and ($package_ensure == 'purged') {
+  if ($facts['os']['family'] == 'RedHat') and ($package_ensure == 'purged') {
     $_package_ensure = 'absent'
   }
   else {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-haveged",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "author": "SIMP Team",
   "summary": "Install and manage the HAVEGE daemon.",
   "license": "BSD-2-Clause",
@@ -16,7 +16,7 @@
   "dependencies": [
     {
       "name": "puppet/systemd",
-      "version_requirement": ">= 3.0.0 < 4.0.0"
+      "version_requirement": ">= 4.0.2 < 6.0.0"
     },
     {
       "name": "simp/simplib",
@@ -24,7 +24,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 6.6.0 < 8.0.0"
+      "version_requirement": ">= 8.0.0 < 9.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
This patch adds support for RockyLinux 8

The patch enforces a standardized asset baseline using simp/puppetsync,
and may also apply other updates to ensure conformity.