### PR TITLE
Finalize RockyLinux 8 support

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -117,6 +117,7 @@ jobs:
             puppet_version: '~> 8.0'
             ruby_version: 3.1
             experimental: true
+      fail-fast: false
     env:
       PUPPET_VERSION: ${{matrix.puppet.puppet_version}}
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ dist
 /junit
 /log
 /doc
+/Gemfile.lock

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -340,6 +340,7 @@ pup7.pe-unit:
   <<: *pup_7_pe
   <<: *unit_tests
 
+# Commenting until Puppet 8 is released
 #pup8.x-unit:
 #  <<: *pup_8_x
 #  <<: *unit_tests

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -7,9 +7,9 @@
 ### Classes
 
 * [`haveged`](#haveged): Manage HAVEGEd  == Sample Usage:    class { 'haveged':     write_wakeup_threshold => 1024,   }
-* [`haveged::config`](#havegedconfig): Manage the HAVEGEd configuration file
-* [`haveged::package`](#havegedpackage): Manage the haveged package
-* [`haveged::service`](#havegedservice): Manage the HAVEGEd service
+* [`haveged::config`](#haveged--config): Manage the HAVEGEd configuration file
+* [`haveged::package`](#haveged--package): Manage the haveged package
+* [`haveged::service`](#haveged--service): Manage the HAVEGEd service
 
 ## Classes
 
@@ -27,50 +27,50 @@ Manage HAVEGEd
 
 The following parameters are available in the `haveged` class:
 
-* [`buffer_size`](#buffer_size)
-* [`data_cache_size`](#data_cache_size)
-* [`instruction_cache_size`](#instruction_cache_size)
-* [`write_wakeup_threshold`](#write_wakeup_threshold)
-* [`service_name`](#service_name)
-* [`service_ensure`](#service_ensure)
-* [`service_enable`](#service_enable)
-* [`package_name`](#package_name)
-* [`package_ensure`](#package_ensure)
+* [`buffer_size`](#-haveged--buffer_size)
+* [`data_cache_size`](#-haveged--data_cache_size)
+* [`instruction_cache_size`](#-haveged--instruction_cache_size)
+* [`write_wakeup_threshold`](#-haveged--write_wakeup_threshold)
+* [`service_name`](#-haveged--service_name)
+* [`service_ensure`](#-haveged--service_ensure)
+* [`service_enable`](#-haveged--service_enable)
+* [`package_name`](#-haveged--package_name)
+* [`package_ensure`](#-haveged--package_ensure)
 
-##### <a name="buffer_size"></a>`buffer_size`
+##### <a name="-haveged--buffer_size"></a>`buffer_size`
 
 Data type: `Optional[Variant[String,Integer]]`
 
 The size of the collection buffer in KB
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="data_cache_size"></a>`data_cache_size`
+##### <a name="-haveged--data_cache_size"></a>`data_cache_size`
 
 Data type: `Optional[Variant[String,Integer]]`
 
 The data cache size in KB
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="instruction_cache_size"></a>`instruction_cache_size`
+##### <a name="-haveged--instruction_cache_size"></a>`instruction_cache_size`
 
 Data type: `Optional[Variant[String,Integer]]`
 
 The instruction cache size in KB. Default is 16 or as determined by cpuid
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="write_wakeup_threshold"></a>`write_wakeup_threshold`
+##### <a name="-haveged--write_wakeup_threshold"></a>`write_wakeup_threshold`
 
-Data type: `Optional[Variant[String,Integer]]`
+Data type: `Variant[String,Integer]`
 
 The haveged daemon generates more data if the number of entropy bits
 falls below this value
 
 Default value: `1024`
 
-##### <a name="service_name"></a>`service_name`
+##### <a name="-haveged--service_name"></a>`service_name`
 
 Data type: `String[1]`
 
@@ -78,7 +78,7 @@ The name of the service to manage
 
 Default value: `'haveged'`
 
-##### <a name="service_ensure"></a>`service_ensure`
+##### <a name="-haveged--service_ensure"></a>`service_ensure`
 
 Data type: `Variant[Boolean,String[1]]`
 
@@ -86,15 +86,15 @@ Whether the service should be running
 
 Default value: `'running'`
 
-##### <a name="service_enable"></a>`service_enable`
+##### <a name="-haveged--service_enable"></a>`service_enable`
 
 Data type: `Boolean`
 
 Whether the service should be enabled to start at boot time
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="package_name"></a>`package_name`
+##### <a name="-haveged--package_name"></a>`package_name`
 
 Data type: `String[1]`
 
@@ -102,7 +102,7 @@ The name of the package to manage
 
 Default value: `'haveged'`
 
-##### <a name="package_ensure"></a>`package_ensure`
+##### <a name="-haveged--package_ensure"></a>`package_ensure`
 
 Data type: `Variant[Boolean,Simplib::PackageEnsure]`
 
@@ -110,7 +110,7 @@ Ensure parameter passed onto Package resources. Default: 'present'
 
 Default value: `simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' })`
 
-### <a name="havegedconfig"></a>`haveged::config`
+### <a name="haveged--config"></a>`haveged::config`
 
 Manage the HAVEGEd configuration file
 
@@ -118,45 +118,45 @@ Manage the HAVEGEd configuration file
 
 The following parameters are available in the `haveged::config` class:
 
-* [`buffer_size`](#buffer_size)
-* [`data_cache_size`](#data_cache_size)
-* [`instruction_cache_size`](#instruction_cache_size)
-* [`write_wakeup_threshold`](#write_wakeup_threshold)
+* [`buffer_size`](#-haveged--config--buffer_size)
+* [`data_cache_size`](#-haveged--config--data_cache_size)
+* [`instruction_cache_size`](#-haveged--config--instruction_cache_size)
+* [`write_wakeup_threshold`](#-haveged--config--write_wakeup_threshold)
 
-##### <a name="buffer_size"></a>`buffer_size`
+##### <a name="-haveged--config--buffer_size"></a>`buffer_size`
 
 Data type: `Optional[Variant[Pattern['^[0-9]+$'],Integer]]`
 
 The size of the collection buffer in KB
 
-Default value: `defined('$haveged::buffer_size')`
+Default value: `defined('$haveged::buffer_size') ? { true => getvar('haveged::buffer_size'), default => undef`
 
-##### <a name="data_cache_size"></a>`data_cache_size`
+##### <a name="-haveged--config--data_cache_size"></a>`data_cache_size`
 
 Data type: `Optional[Variant[Pattern['^[0-9]+$'],Integer]]`
 
 The data cache size in KB
 
-Default value: `defined('$haveged::data_cache_size')`
+Default value: `defined('$haveged::data_cache_size') ? { true => getvar('haveged::data_cache_size'), default => undef`
 
-##### <a name="instruction_cache_size"></a>`instruction_cache_size`
+##### <a name="-haveged--config--instruction_cache_size"></a>`instruction_cache_size`
 
 Data type: `Optional[Variant[Pattern['^[0-9]+$'],Integer]]`
 
 The instruction cache size in KB
 
-Default value: `defined('$haveged::instruction_cache_size')`
+Default value: `defined('$haveged::instruction_cache_size') ? { true => getvar('haveged::instruction_cache_size'), default => undef`
 
-##### <a name="write_wakeup_threshold"></a>`write_wakeup_threshold`
+##### <a name="-haveged--config--write_wakeup_threshold"></a>`write_wakeup_threshold`
 
 Data type: `Optional[Variant[Pattern['^[0-9]+$'],Integer]]`
 
 The haveged daemon generates more data if the number of entropy bits
 falls below this value
 
-Default value: `defined('$haveged::write_wakeup_threshold')`
+Default value: `defined('$haveged::write_wakeup_threshold') ? { true => getvar('haveged::write_wakeup_threshold'), default => undef`
 
-### <a name="havegedpackage"></a>`haveged::package`
+### <a name="haveged--package"></a>`haveged::package`
 
 Manage the haveged package
 
@@ -164,26 +164,26 @@ Manage the haveged package
 
 The following parameters are available in the `haveged::package` class:
 
-* [`package_name`](#package_name)
-* [`package_ensure`](#package_ensure)
+* [`package_name`](#-haveged--package--package_name)
+* [`package_ensure`](#-haveged--package--package_ensure)
 
-##### <a name="package_name"></a>`package_name`
+##### <a name="-haveged--package--package_name"></a>`package_name`
 
 Data type: `String[1]`
 
 The name of the package to manage
 
-Default value: `defined('$haveged::package_name')`
+Default value: `defined('$haveged::package_name') ? { true => getvar('haveged::package_name'), default => 'haveged'`
 
-##### <a name="package_ensure"></a>`package_ensure`
+##### <a name="-haveged--package--package_ensure"></a>`package_ensure`
 
 Data type: `Simplib::PackageEnsure`
 
 Ensure parameter passed onto Package resources
 
-Default value: `defined('$haveged::_package_ensure')`
+Default value: `defined('$haveged::_package_ensure') ? { true => getvar('haveged::_package_ensure'), default => 'present'`
 
-### <a name="havegedservice"></a>`haveged::service`
+### <a name="haveged--service"></a>`haveged::service`
 
 Manage the HAVEGEd service
 
@@ -191,36 +191,36 @@ Manage the HAVEGEd service
 
 The following parameters are available in the `haveged::service` class:
 
-* [`service_name`](#service_name)
-* [`service_ensure`](#service_ensure)
-* [`service_enable`](#service_enable)
-* [`force_if_rngd_running`](#force_if_rngd_running)
+* [`service_name`](#-haveged--service--service_name)
+* [`service_ensure`](#-haveged--service--service_ensure)
+* [`service_enable`](#-haveged--service--service_enable)
+* [`force_if_rngd_running`](#-haveged--service--force_if_rngd_running)
 
-##### <a name="service_name"></a>`service_name`
+##### <a name="-haveged--service--service_name"></a>`service_name`
 
 Data type: `String[1]`
 
 The name of the service to manage
 
-Default value: `defined('$haveged::service_name')`
+Default value: `defined('$haveged::service_name') ? { true => getvar('haveged::service_name'), default => 'haveged'`
 
-##### <a name="service_ensure"></a>`service_ensure`
+##### <a name="-haveged--service--service_ensure"></a>`service_ensure`
 
 Data type: `String[1]`
 
 Whether the service should be running
 
-Default value: `defined('$haveged::_service_ensure')`
+Default value: `defined('$haveged::_service_ensure') ? { true => getvar('haveged::_service_ensure'), default => 'running'`
 
-##### <a name="service_enable"></a>`service_enable`
+##### <a name="-haveged--service--service_enable"></a>`service_enable`
 
 Data type: `Boolean`
 
 Whether the service should be enabled to start at boot time
 
-Default value: `defined('$haveged::_service_enable')`
+Default value: `defined('$haveged::_service_enable') ? { true => getvar('haveged::_service_enable'), default => true`
 
-##### <a name="force_if_rngd_running"></a>`force_if_rngd_running`
+##### <a name="-haveged--service--force_if_rngd_running"></a>`force_if_rngd_running`
 
 Data type: `Boolean`
 
@@ -229,5 +229,5 @@ Will force haveged to start even though RNGD is already running
 * While this should not harm your system in most cases, it is also adding
   an unnecessary process running on the system
 
-Default value: ``false``
+Default value: `false`
 


### PR DESCRIPTION
This patch adds support for RockyLinux 8

The patch enforces a standardized asset baseline using simp/puppetsync,
and may also apply other updates to ensure conformity.